### PR TITLE
Upgrade to Scala 2.13.0-M4

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -3,13 +3,14 @@ import Keys._
 
 object build extends Build {
   lazy val sharedSettings = Defaults.defaultSettings ++ Seq(
-    scalaVersion := "2.13.0-M3",
+    scalaVersion := "2.13.0-pre-66da69b",
     crossVersion := CrossVersion.full,
     version := "2.1.0-SNAPSHOT",
     organization := "org.scalamacros",
     description := "Empowers production Scala compiler with latest macro developments",
     resolvers += Resolver.sonatypeRepo("snapshots"),
     resolvers += Resolver.sonatypeRepo("releases"),
+    resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
     publishMavenStyle := true,
     publishArtifact in Test := false,
     scalacOptions ++= Seq("-deprecation", "-feature"),

--- a/tests/src/main/scala/kase.scala
+++ b/tests/src/main/scala/kase.scala
@@ -98,7 +98,7 @@ object kaseMacro {
             val secondaryCopyParamss = secondaryParamss.map(_.map(p => ValDef(unmakeDefault(unmakeCaseAccessor(p.mods)), p.name, p.tpt, EmptyTree)))
             val copyParamss = primaryCopyParamss :: secondaryCopyParamss
             val copyArgss = copyParamss.map(_.map(p => Ident(p.name)))
-            val copyBody = ((Select(New(Ident(cdef.name)), termNames.CONSTRUCTOR): Tree) /: copyArgss)((callee, args) => Apply(callee, args))
+            val copyBody = copyArgss.foldLeft(Select(New(Ident(cdef.name)), termNames.CONSTRUCTOR): Tree)((callee, args) => Apply(callee, args))
             val copyMethod = DefDef(SyntheticMods, TermName("copy"), copyTparams, copyParamss, TypeTree(), copyBody)
             cbody2 :+ copyMethod
           }
@@ -205,7 +205,7 @@ object kaseMacro {
           val applyTparams = tparams.map(p => TypeDef(unmakeVariant(p.mods), p.name, p.tparams, p.rhs))
           val applyParamss = primaryParamss.map(_.map(p => ValDef(unmakeCaseAccessor(p.mods), p.name, p.tpt, p.rhs)))
           val applyArgss = applyParamss.map(_.map(p => Ident(p.name)))
-          val applyBody = ((Select(New(ourPolyType), termNames.CONSTRUCTOR): Tree) /: applyArgss)((callee, args) => Apply(callee, args))
+          val applyBody = applyArgss.foldLeft(Select(New(ourPolyType), termNames.CONSTRUCTOR): Tree)((callee, args) => Apply(callee, args))
           val applyMethod = DefDef(SyntheticCaseMods, TermName("apply"), applyTparams, applyParamss, TypeTree(), applyBody)
           mbody1 :+ applyMethod
         }


### PR DESCRIPTION
It seems that apart from the `/:` operator that has been deprecated no other change is required to make macro paradise plugin compile.

That being said, I’m having the following compiler crash when trying to compile the tests:

~~~
[error] 
[error]   last tree to typer: TypeTree(trait Product)
[error]        tree position: line 8 of /home/julien/workspace/dev/scalamacros/paradise/tests/src/test/scala/run/Multiple.scala
[error]             tree tpe: Product
[error]               symbol: abstract trait Product in package scala
[error]    symbol definition: abstract trait Product extends Any with Equals (a ClassSymbol)
[error]       symbol package: scala
[error]        symbol owners: trait Product
[error]            call site: object DD in class Multiple in package <empty>
[error] 
[error] == Source file context for tree position ==
[error] 
[error]      5 
[error]      6 @RunWith(classOf[JUnit4])
[error]      7 class Multiple {
[error]      8   @doubler @doubler case object D
[error]      9 
[error]     10   @Test
[error]     11   def multiple: Unit = {
~~~

I’m not sure where to look for? Could it be due to a regression in the new collections?

Also: should I create a `2.13.0-M4` branch here? What should its parent branch be?